### PR TITLE
add cpp in code snippet

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -41,7 +41,7 @@ MKRIoTCarrier yourName; //In the examples we name it as *carrier*
 
 Intialization example sketch
 
-```
+```cpp
 #include <Arduino_MKRIoTCarrier.h>
 MKRIoTCarrier carrier;
 


### PR DESCRIPTION
Set cpp in the fence area to improve reference website support.
`arduino` (or `ino`) are also valid styles for our reference website and will be styled accordingly.