### PR TITLE
Fix RGB LEDs colour order

### DIFF
--- a/src/Arduino_MKRIoTCarrier.h
+++ b/src/Arduino_MKRIoTCarrier.h
@@ -125,7 +125,6 @@ class MKRIoTCarrier{
     Adafruit_ST7789 display = Adafruit_ST7789(&SPI, TFT_CS, TFT_DC, -1);
 	
     //RGB LEDs
-    Adafruit_DotStar leds = Adafruit_DotStar(NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BRG);
-  private:
+    Adafruit_DotStar leds = Adafruit_DotStar(NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BGR);
 };
 #endif


### PR DESCRIPTION
The current colour arrangement used for DotStar has Green and Red swapped.
At least on my unit this is what I experience.
This PR fixes the order to `DOTSTAR_BGR`, but it might be useful to check if different batches of APA102c ordered for production might have different colour order