### PR TITLE
Broken link library page

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,7 +10,7 @@ Read more about the Kits:
 
 
 For more information about this library please visit us at
-http://www.arduino.cc/en/Reference/MKRIoTCarrier
+https://www.arduino.cc/reference/en/libraries/arduino_mkriotcarrier/
 
 ## License 
 


### PR DESCRIPTION
The link to the library page was wrong, I updated it with the correct one. 

From this Jira Task: https://arduino.atlassian.net/browse/CNT-941?atlOrigin=eyJpIjoiNTg5ZTE3YjAzOGQ0NDdjMzg1NWFkMmQ4NDI5YzEwODkiLCJwIjoiaiJ9