### PR TITLE
Fixed Relays

### DIFF
--- a/src/Arduino_MKRIoTCarrier.cpp
+++ b/src/Arduino_MKRIoTCarrier.cpp
@@ -71,9 +71,11 @@ int MKRIoTCarrier::begin() {
     }
     return false;
   }
-
+  Relay1.begin();
+  Relay2.begin();
   if(!SD.begin(SD_CS)) {
     Serial.println("Sd card not detected");
   }
+
   return true;
 }

--- a/src/Arduino_MKRIoTCarrier_Relay.cpp
+++ b/src/Arduino_MKRIoTCarrier_Relay.cpp
@@ -20,13 +20,16 @@
 
 #include "Arduino_MKRIoTCarrier_Relay.h"
 
-MKRIoTCarrier_Relay::MKRIoTCarrier_Relay(int pin){
-    _pin = pin;
+MKRIoTCarrier_Relay::MKRIoTCarrier_Relay(int pin):_pin{pin}
+{
+}
+void MKRIoTCarrier_Relay::begin(){
     pinMode(_pin ,OUTPUT);
     close();
-    
 }
-
+int MKRIoTCarrier_Relay::getPin(){
+    return _pin;
+}
 //NC state
 void MKRIoTCarrier_Relay::close(){
     digitalWrite(_pin , LOW);

--- a/src/Arduino_MKRIoTCarrier_Relay.h
+++ b/src/Arduino_MKRIoTCarrier_Relay.h
@@ -26,14 +26,14 @@
 class MKRIoTCarrier_Relay{
     public: 
     MKRIoTCarrier_Relay(int pin);
-    
+    void begin();
     void open();
     void close();
-
+    int getPin();
     int getStatus();
 
     private:
-    int _pin;
+    const int _pin;
     int _status;
 };
 


### PR DESCRIPTION
I have had reports from a user in a FB group about the `Relay_blink` example not working and I verified it didn't.
I ended up adding a `begin()` method to the `MRKIOTCarrier_Relay` Class to set the `pinMode()`.
The `MKRIoTCarrier::begin()` method now invokes these for `Relay_1` and `Relay_2`.
Also set the `_pin` private member in the initializer list to make it `const int`.

Tested and working, but please run your tests