### PR TITLE
Add more Arduinish methods to set CARRIER_CASE

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -58,8 +58,6 @@ MKRIoTCarrier carrier;
 
 setup(){
 Serial.begin(9600);
-//This will adjust the sensitivity of the touch pads, not mandatory to set it, by default is false
-CARRIER_CASE = false; 
 if(!carrier.begin(){  //It will see any sensor failure
    Serial.println("Failure on init");
    while(1);
@@ -84,7 +82,6 @@ MKRIoTCarrier carrier;
 File myFile;
 
 setup(){
-   CARRIER_CASE = false; 
    carrier.begin();  //SD card initialized here
    
    myFile = SD.open("test.txt", FILE_WRITE);
@@ -127,7 +124,7 @@ ButtonX.onTouchChange()
 ```
 
 In case you have another enclosure you can change the sensitivity of the pads, 3-100
-Automatically configured when you set the `CARRIER_CASE` boolean, by default is false (sensitivity threshold 4)
+Automatically configured when you call `carrier.withCase()`, by default is false (sensitivity threshold 4)
 
 ```cpp
 ButtonX.updateConfig(int newSens)
@@ -140,7 +137,6 @@ MKRIoTCarrier carrier;
 
 void setup(){
    Serial.begin(9600);
-   CARRIER_CASE = true/false;
    carrier.begin();
 }
 
@@ -204,7 +200,6 @@ MKRIoTCarrier carrier;
 uint32_t myCustomColor = carrier.leds.Color(255,100,50);
 
 void setup(){
-   CARRIER_CASE = false;
    carrier.begin();
    carrier.leds.fill(myCustomColor, 0, 5);
    carrier.leds.show();

--- a/examples/Actuators/Buzzer_Melody/Buzzer_Melody.ino
+++ b/examples/Actuators/Buzzer_Melody/Buzzer_Melody.ino
@@ -20,7 +20,6 @@ int noteDurations[] = {
 };
 
 void setup() {
-  CARRIER_CASE = false;
   carrier.begin();
   
   // iterate over the notes of the melody:

--- a/examples/Actuators/Relays_blink/Relays_blink.ino
+++ b/examples/Actuators/Relays_blink/Relays_blink.ino
@@ -6,7 +6,7 @@ void setup() {
 
   Serial.begin(9600);
   Serial.println("Init");
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/All_Features/All_Features.ino
+++ b/examples/All_Features/All_Features.ino
@@ -24,7 +24,7 @@ void setup() {
   while (!Serial);  //Wait to open the Serial monitor to start the program and see details on errors
 
   //Init everything and outputs the errors
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/Display/Compose_images/Compose_images.ino
+++ b/examples/Display/Compose_images/Compose_images.ino
@@ -15,7 +15,7 @@ uint32_t orange = carrier.leds.Color(50, 242, 0);
 
 void setup() {
   Serial.begin(9600);
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 
   uint16_t time = millis();

--- a/examples/Display/Graphics/Graphics.ino
+++ b/examples/Display/Graphics/Graphics.ino
@@ -11,7 +11,7 @@ void setup(void) {
   
   Serial.begin(9600);
   Serial.print(F("Hello! ST77xx TFT Test"));
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 
   uint16_t time = millis();

--- a/examples/Display/Show_GIF/Show_GIF.ino
+++ b/examples/Display/Show_GIF/Show_GIF.ino
@@ -18,7 +18,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
 
   carrier.begin();
   carrier.display.setRotation(4);

--- a/examples/Grove_Inputs/Grove_Inputs.ino
+++ b/examples/Grove_Inputs/Grove_Inputs.ino
@@ -11,7 +11,7 @@ void setup() {
   // put your setup code here, to run once:
   Serial.begin(9600);
   while(!Serial);
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
   pinMode(moisture,INPUT);
   pinMode(pir,INPUT);

--- a/examples/LEDs-Examples/strandtest/strandtest.ino
+++ b/examples/LEDs-Examples/strandtest/strandtest.ino
@@ -4,7 +4,7 @@ MKRIoTCarrier carrier;
 #define NUMPIXELS 5
 
 void setup() {
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/SD_card/SD_card.ino
+++ b/examples/SD_card/SD_card.ino
@@ -11,7 +11,7 @@ void setup() {
   }
 
   //  Init the entire Carrier
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
   
   // open the file. note that only one file can be open at a time,

--- a/examples/Sensors/ENV-HTS221/ReadSensors/ReadSensors.ino
+++ b/examples/Sensors/ENV-HTS221/ReadSensors/ReadSensors.ino
@@ -10,7 +10,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/Sensors/ENV-HTS221/ReadSensorsImperial/ReadSensorsImperial.ino
+++ b/examples/Sensors/ENV-HTS221/ReadSensorsImperial/ReadSensorsImperial.ino
@@ -10,7 +10,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/Sensors/IMU-LSM6DS3/SimpleGyroscope/SimpleGyroscope.ino
+++ b/examples/Sensors/IMU-LSM6DS3/SimpleGyroscope/SimpleGyroscope.ino
@@ -21,7 +21,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Failed to initialize!");
 

--- a/examples/Sensors/Light-APDS9960/FullExample/FullExample.ino
+++ b/examples/Sensors/Light-APDS9960/FullExample/FullExample.ino
@@ -21,7 +21,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial); // Wait for serial monitor to open
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Error");
     while (true); // Stop forever

--- a/examples/Sensors/Light-APDS9960/GestureSensor/GestureSensor.ino
+++ b/examples/Sensors/Light-APDS9960/GestureSensor/GestureSensor.ino
@@ -23,7 +23,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Error");
   }

--- a/examples/Sensors/Light-APDS9960/ProximitySensor/ProximitySensor.ino
+++ b/examples/Sensors/Light-APDS9960/ProximitySensor/ProximitySensor.ino
@@ -18,7 +18,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Error initializing APDS9960 sensor!");
   }

--- a/examples/Sensors/Light-APDS9960/Read_Colors/Read_Colors.ino
+++ b/examples/Sensors/Light-APDS9960/Read_Colors/Read_Colors.ino
@@ -9,7 +9,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/Sensors/Pressure-LPS22HB/ReadPressure/ReadPressure.ino
+++ b/examples/Sensors/Pressure-LPS22HB/ReadPressure/ReadPressure.ino
@@ -18,7 +18,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
   
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Failed to initialize!");
     while (1);

--- a/examples/Sensors/Pressure-LPS22HB/ReadPressureImperial/ReadPressureImperial.ino
+++ b/examples/Sensors/Pressure-LPS22HB/ReadPressureImperial/ReadPressureImperial.ino
@@ -18,7 +18,7 @@ void setup() {
   Serial.begin(9600);
   while (!Serial);
 
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Failed to initialize!");
     while (1);

--- a/examples/TouchPads/Custom_Sensitivity/Custom_Sensitivity.ino
+++ b/examples/TouchPads/Custom_Sensitivity/Custom_Sensitivity.ino
@@ -1,8 +1,8 @@
 #include "Arduino_MKRIoTCarrier.h"
 MKRIoTCarrier carrier;
 
-// When CARRIER_CASE is false it's set to 100 (closer)
-// When CARRIER_CASE is true it's set to 4  (further)
+// When calling carrier.noCase() (default) it's set to 100 (closer)
+// When calling carrier.case() it's set to 4  (further)
 // But if you use Buttons.updateConfig(value) It will not set the above values
 
 unsigned int threshold = 98;
@@ -14,7 +14,7 @@ void setup() {
   while (!Serial);
 
   carrier.begin();
-  //CARRIER_CASE = false;
+  //carrier.noCase();
   //Now we can set our custom touch threshold
   // First we update all the buttons with the new threshold
   // Then we overwrite individually one of them (they can be all set individually too)

--- a/examples/TouchPads/Relays_control_Qtouch/Relays_control_Qtouch.ino
+++ b/examples/TouchPads/Relays_control_Qtouch/Relays_control_Qtouch.ino
@@ -16,7 +16,7 @@ void setup() {
   // put your setup code here, to run once:
   Serial.begin(9600);
   
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 
   carrier.leds.setPixelColor(0, c_green);

--- a/examples/TouchPads/TouchTypes/TouchTypes.ino
+++ b/examples/TouchPads/TouchTypes/TouchTypes.ino
@@ -17,8 +17,7 @@ MKRIoTCarrier carrier;
 void setup() {
   Serial.begin(9600);
   while (!Serial);
-  // Qtouch initialization
-  CARRIER_CASE = false;
+  carrier.noCase();
   if (!carrier.begin()) {
     Serial.println("Error in sensors initialization!");
     while (1);

--- a/examples/TouchPads/Touch_and_LEDs/Touch_and_LEDs.ino
+++ b/examples/TouchPads/Touch_and_LEDs/Touch_and_LEDs.ino
@@ -8,7 +8,7 @@ void setup() {
   while (!Serial);
 
   //Init all the components from the board
-  CARRIER_CASE = false;
+  carrier.noCase();
   carrier.begin();
 }
 

--- a/examples/TouchPads/Touch_signals/Touch_signals.ino
+++ b/examples/TouchPads/Touch_signals/Touch_signals.ino
@@ -7,7 +7,7 @@ int msr[5];
 
 void setup() {
   // put your setup code here, to run once:
-  //CARRIER_CASE = false;     //No needed to use it, default false
+  //carrier.noCase();     //No need to use it, default false
   Serial.begin(9600);
   carrier.begin();
   

--- a/src/Arduino_MKRIoTCarrier.h
+++ b/src/Arduino_MKRIoTCarrier.h
@@ -93,6 +93,10 @@ class MKRIoTCarrier{
     MKRIoTCarrier();
     int begin();
 
+    // Case
+    void withCase() { CARRIER_CASE = true; };
+    void noCase()   { CARRIER_CASE = false; };
+
     //Sensors
     APDS9960& Light = APDS;
     LPS22HBClass& Pressure = BARO;


### PR DESCRIPTION
As of now, the configuration of the library involves setting a global variable called `CARRIER_CASE`. This is not very Arduino-style and created some confusion in users who are asked to set a variable which is not declared within the sketch itself.

This pull request adds two methods that are more in line with the Arduino API style:

```
carrier.withCase();
```

```
carrier.noCase();
```

This change is retrocompatible so any sketch and tutorial using `CARRIER_CASE` is still valid, but for new content we might want to provide the new better looking calls.

This fixes #13.