### PR TITLE
Fix overwriting single button sensitivity

### DIFF
--- a/examples/TouchPads/Custom_Sensitivity/Custom_Sensitivity.ino
+++ b/examples/TouchPads/Custom_Sensitivity/Custom_Sensitivity.ino
@@ -19,8 +19,7 @@ void setup() {
   // First we update all the buttons with the new threshold
   // Then we overwrite individually one of them (they can be all set individually too)
   carrier.Buttons.updateConfig(threshold);
-  carrier.Buttons.updateConfig(threshold_btn_0);
-
+  carrier.Buttons.updateConfig(threshold_btn_0, TOUCH0);
 }
 
 void loop() {


### PR DESCRIPTION
Hi everyone, the syntax for updating an individual button sensitivity should be [like this](https://github.com/arduino-libraries/Arduino_MKRIoTCarrier/blob/master/src/Arduino_MKRIoTCarrier_Qtouch.h#L45):

```cpp
void updateConfig(int newSens, touchButtons padIndex);
```

I think this example means to do that, but it's missing the `padIndex`, so I have added it.