### PR TITLE
Fix Display issue

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -220,7 +220,7 @@ leds.begin()
 
 Sets the color of the index’s LED
 ```cpp
-leds.setPixelColor(index, green, red, blue)
+leds.setPixelColor(index, red, green, blue)
 ```
 
 In case you have custom colors you can use this method too
@@ -250,7 +250,7 @@ leds.fill(color, firstLedToCount, count)
 
 Save your custom color:
 ```cpp
-uint32_t myColor = carrier.leds.Color(green, red, blue)
+uint32_t myColor = carrier.leds.Color(red, green, blue)
 ```
 
 ### Pressure sensor - LPS22HB (Barometric)

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Arduino_MKRIoTCarrier
-version=1.0.2
+version=1.0.4
 author=Riccardo Rizzo, Jose García, Pablo Marquínez
 maintainer=Arduino <info@arduino.cc>
 sentence=Controlling the IoT MKR Carrier

--- a/src/Arduino_MKRIoTCarrier.h
+++ b/src/Arduino_MKRIoTCarrier.h
@@ -122,7 +122,7 @@ class MKRIoTCarrier{
     MKRIoTCarrierQtouch Button4 __attribute__((deprecated)) = MKRIoTCarrierQtouch(TOUCH4);
 
     //Display
-    Adafruit_ST7789 display = Adafruit_ST7789(&SPI, TFT_CS, TFT_DC, -1);
+    Adafruit_ST7789 display = Adafruit_ST7789(TFT_CS, TFT_DC, -1);
 	
     //RGB LEDs
     Adafruit_DotStar leds = Adafruit_DotStar(NUMPIXELS, DATAPIN, CLOCKPIN, DOTSTAR_BGR);


### PR DESCRIPTION
* Display constructor fixed to last version updates, discover issue with `display.println()`
* Fix LEDs RGB order to `RGB` instead of `BGR`
* Bump version correctly (didnt do it in the latest release)