### PR TITLE
Pin "BSEC Software Library" dependency at working version

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Sensors
 url=https://github.com/arduino-libraries/Arduino_MKRIoTCarrier
 architectures=samd
 precompiled=false
-depends=Arduino_APDS9960,Arduino_BQ24195,Arduino_HTS221,Arduino_LPS22HB,Arduino_LSM6DS3,Arduino_LSM6DSOX,BSEC Software Library,Adafruit BusIO,Adafruit DotStar,Adafruit GFX Library,Adafruit ST7735 and ST7789 Library,Arduino_MCHPTouch,TFT_eSPI
+depends=Arduino_APDS9960,Arduino_BQ24195,Arduino_HTS221,Arduino_LPS22HB,Arduino_LSM6DS3,Arduino_LSM6DSOX,BSEC Software Library (=1.6.1480),Adafruit BusIO,Adafruit DotStar,Adafruit GFX Library,Adafruit ST7735 and ST7789 Library,Arduino_MCHPTouch,TFT_eSPI


### PR DESCRIPTION
The "**Arduino_MKRIoTCarrier**" library has a dependency on "[**BSEC Software Library**](https://github.com/boschsensortec/BSEC-Arduino-library)". The recent [**1.7.1492** release](https://github.com/boschsensortec/BSEC-Arduino-library/releases/tag/v1.7.1492) of that library has a bug in its `#include` directives that causes compilation to fail with a "`No such file or directory`" error (https://github.com/boschsensortec/BSEC-Arduino-library/pull/58, https://github.com/arduino-libraries/Arduino_MKRIoTCarrier/issues/69).

When "**Arduino_MKRIoTCarrier**" is installed via the Arduino Library Manager, the dependencies listed in the `depends` metadata field are also installed. Arduino IDE 2.x and Arduino CLI (>=0.7.0) support version constraints in this field:

https://arduino.github.io/arduino-cli/latest/library-specification/#version-constraints

If a constraint is provided in this field, Library Manager will install the appropriate version of the dependency. Arduino IDE 1.x does not recognize dependency version constraints, but is compatible with this metadata in that it is simply ignored and does not cause any change in the behavior of the Library Manager installation.

Using the version constraint to "pin" "**BSEC Software Library**" to the last good version (**1.6.1480**) will mitigate the breakage caused by the bad **1.7.1492** release of that dependency by ensuring the good version is installed along with "**Arduino_MKRIoTCarrier**" when the user does the installation via the Arduino IDE 2.x or Arduino CLI Library Manager. It is only a partial mitigation because breakage will still be experienced by users under other conditions:

- Using [**Arduino Cloud**](https://cloud.arduino.cc/) (which will use the latest available dependency version regardless of constraints in the metadata)
- Using Arduino IDE 1.x
- Updates "**BSEC Software Library**" separately