### PR TITLE
Add AREF_PIN for the MKR WAN 1310

### DIFF
--- a/src/MKRIoTCarrierDefines.h
+++ b/src/MKRIoTCarrierDefines.h
@@ -90,7 +90,7 @@ namespace mkr_iot_carrier_rev2 {
 #define LSM6DSOX_ADDRESS           0x6A
 #define LSM6DS3_ADDRESS            0x6A
 
-#ifdef ARDUINO_SAMD_MKRWIFI1010
+#if defined(ARDUINO_SAMD_MKRWIFI1010) || defined(ARDUINO_SAMD_MKRWAN1310)
 #define AREF_PIN 25
 #endif
 


### PR DESCRIPTION
During an IOT course, the entire class got the same issue being the `AREF_PIN` not being defined using the MKR WAN 1310 board.

Issue: `Arduino_MKRIoTCarrier.cpp:34:11: error: 'AREF_PIN' was not declared in this scope`